### PR TITLE
Ability to add nested lifecycle plugins from pipelineexecute stages

### DIFF
--- a/src/main/scala/ai/tripl/arc/config/ArcPipeline.scala
+++ b/src/main/scala/ai/tripl/arc/config/ArcPipeline.scala
@@ -96,14 +96,24 @@ object ArcPipeline {
             case (Left(lifecycleErrors), Right(_)) => Left(lifecycleErrors.reverse)
             case (Right(lifecycleInstances), Right(pipelineInstances)) => {
 
-              // flatten any PipelineExecuteStage stages
-              val flatPipelineInstances: List[PipelineStage] = pipelineInstances.flatMap {
-                instance => {
-                  instance match {
-                    case ai.tripl.arc.execute.PipelineExecuteStage(_, _, _, _, pipeline) => pipeline.stages
-                    case stage: PipelineStage => List(stage)
+              // flatten any PipelineExecuteStage stages and their LifecylePlugins
+              val stages: List[(List[PipelineStage], List[LifecyclePluginInstance])] = pipelineInstances.map {
+                pipelineStage => {
+                  pipelineStage match {
+                    case ai.tripl.arc.execute.PipelineExecuteStage(_, _, _, _, pipeline, pipelineLifecycleInstances) => (pipeline.stages, pipelineLifecycleInstances)
+                    case pipelineStage: PipelineStage => (List(pipelineStage), List.empty)
                   }
                 }
+              }
+
+              // flatPipelineInstances is a merge of all the pipeline plugins
+              val flatPipelineInstances = stages.flatMap{
+                case (pipelineStage, _) => pipelineStage
+              }
+
+              // activeLifecyclePluginInstances is a merge of all the lifecycle plugins
+              val activeLifecyclePluginInstances = stages.foldLeft(lifecycleInstances) { 
+                case (lifecycleInstances, (_, pipelineLifecycleInstances)) => lifecycleInstances ::: pipelineLifecycleInstances
               }
 
               // used the resolved config to add registered lifecyclePlugins to context
@@ -120,7 +130,7 @@ object ArcPipeline {
                 commandLineArguments=arcContext.commandLineArguments,
                 dynamicConfigurationPlugins=arcContext.dynamicConfigurationPlugins,
                 lifecyclePlugins=arcContext.lifecyclePlugins,
-                activeLifecyclePlugins=lifecycleInstances,
+                activeLifecyclePlugins=activeLifecyclePluginInstances,
                 pipelineStagePlugins=arcContext.pipelineStagePlugins,
                 udfPlugins=arcContext.udfPlugins,
                 userData=arcContext.userData

--- a/src/main/scala/ai/tripl/arc/execute/PipelineExecute.scala
+++ b/src/main/scala/ai/tripl/arc/execute/PipelineExecute.scala
@@ -42,7 +42,8 @@ class PipelineExecute extends PipelineStagePlugin {
               name=name,
               description=description,
               uri=uri,
-              pipeline=pipeline
+              pipeline=pipeline,
+              activeLifecyclePlugins=ctx.activeLifecyclePlugins
             )
 
             Right(stage)
@@ -66,7 +67,8 @@ case class PipelineExecuteStage(
     name: String,
     description: Option[String],
     uri: URI,
-    pipeline: ETLPipeline
+    pipeline: ETLPipeline,
+    activeLifecyclePlugins: List[LifecyclePluginInstance]
   ) extends PipelineStage {
 
   override def execute()(implicit spark: SparkSession, logger: ai.tripl.arc.util.log.logger.Logger, arcContext: ARCContext): Option[DataFrame] = {

--- a/src/test/resources/conf/job.ipynb
+++ b/src/test/resources/conf/job.ipynb
@@ -75,8 +75,11 @@
     "%lifecycleplugin\n",
     "{\n",
     "  \"type\": \"ai.tripl.arc.plugins.TestLifecyclePlugin\",\n",
+    "  \"name\": \"test\",\n",
     "  \"environments\": [\"test\"],\n",
-    "  \"key\": \"testValue\"\n",
+    "  \"outputViewBefore\": \"before\",\n",
+    "  \"outputViewAfter\": \"after\",\n",
+    "  \"value\": \"testValue\"\n",
     "}"
    ]
   },

--- a/src/test/resources/conf/pipeline_execute.conf
+++ b/src/test/resources/conf/pipeline_execute.conf
@@ -4,10 +4,10 @@
     {
       "type": "ai.tripl.arc.plugins.TestLifecyclePlugin",
       "environments": ["test"],
-      "name": "lifecyclePluginTest",
-      "outputViewBefore": "before",
-      "outputViewAfter": "after",
-      "value": "testValue"
+      "name": "level1",
+      "outputViewBefore": "level1before",
+      "outputViewAfter": "level1after",
+      "value": "level1"
     }
   ],
 },
@@ -20,6 +20,7 @@
       "test"
     ],
     "inputView": "inputView",
+    "inputField": "value",
     "outputView": "outputView",
     "delimiter": "Comma",
     "quote": "DoubleQuote",

--- a/src/test/scala/ai/tripl/arc/config/ConfigUtilsSuite.scala
+++ b/src/test/scala/ai/tripl/arc/config/ConfigUtilsSuite.scala
@@ -263,7 +263,7 @@ class ConfigUtilsSuite extends FunSuite with BeforeAndAfter {
     val pipelineEither = ArcPipeline.parseConfig(Left(conf), arcContext)
 
     pipelineEither match {
-      case Left(errors) => assert(false)
+      case Left(err) => fail(err.toString)
       case Right((pipeline, _)) => {
         pipeline.stages(0) match {
           case s: extract.DelimitedExtractStage => assert(s.settings.customDelimiter == "%")
@@ -303,7 +303,7 @@ class ConfigUtilsSuite extends FunSuite with BeforeAndAfter {
     val pipelineEither = ArcPipeline.parseConfig(Left(conf), arcContext)
 
     pipelineEither match {
-      case Left(errors) => assert(false)
+      case Left(err) => fail(err.toString)
       case Right((pipeline, _)) => {
         assert(pipeline.stages(0).name == "foo")
       }
@@ -357,10 +357,7 @@ class ConfigUtilsSuite extends FunSuite with BeforeAndAfter {
     val pipelineEither = ArcPipeline.parseConfig(Right(new URI("classpath://conf/pipeline.conf")), arcContext)
 
     pipelineEither match {
-      case Left(errors) => {
-        println(errors)
-        assert(false)
-      }
+      case Left(err) => fail(err.toString)
       case Right((pipeline, _)) => {
         ARC.run(pipeline)
         assert(spark.sql("SELECT * FROM stage4").count == 2)
@@ -444,10 +441,7 @@ class ConfigUtilsSuite extends FunSuite with BeforeAndAfter {
     val pipelineEither = ArcPipeline.parseConfig(Left(conf), arcContext)
 
     pipelineEither match {
-      case Left(errors) => {
-        println(errors)
-        assert(false)
-      }
+      case Left(err) => fail(err.toString)
       case Right((pipeline, _)) => {
         val stage = pipeline.stages(0).asInstanceOf[extract.DelimitedExtractStage]
         assert(stage.watermark.get.eventTime === "timecolumn")
@@ -465,10 +459,7 @@ class ConfigUtilsSuite extends FunSuite with BeforeAndAfter {
     val pipelineEither = ArcPipeline.parseConfig(Right(new URI("classpath://conf/job.ipynb")), arcContext)
 
     pipelineEither match {
-      case Left(errors) => {
-        println(errors)
-        assert(false)
-      }
+      case Left(err) => fail(err.toString)
       case Right((pipeline, arcCtx)) => {
         assert(arcCtx.activeLifecyclePlugins.length == 1)
         assert(arcCtx.dynamicConfigurationPlugins.length == 1)

--- a/src/test/scala/ai/tripl/arc/execute/PipelineExecuteSuite.scala
+++ b/src/test/scala/ai/tripl/arc/execute/PipelineExecuteSuite.scala
@@ -1,0 +1,102 @@
+package ai.tripl.arc
+
+import java.net.URI
+import java.sql.DriverManager
+
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+
+import ai.tripl.arc.api._
+import ai.tripl.arc.api.API._
+import ai.tripl.arc.config._
+import ai.tripl.arc.util._
+import ai.tripl.arc.util.log.LoggerFactory
+
+class PipelineExecuteSuite extends FunSuite with BeforeAndAfter {
+
+  var session: SparkSession = _
+  var connection: java.sql.Connection = _
+
+  before {
+    implicit val spark = SparkSession
+                  .builder()
+                  .master("local[*]")
+                  .config("spark.ui.port", "9999")
+                  .appName("Spark ETL Test")
+                  .getOrCreate()
+    spark.sparkContext.setLogLevel("INFO")
+
+    // set for deterministic timezone
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
+
+    session = spark
+    import spark.implicits._
+  }
+
+  after {
+    session.stop
+  }
+
+  test("PipelineExecute: Nested Lifecycle Plugins") {
+    implicit val spark = session
+    implicit val logger = TestUtils.getLogger()
+    implicit val arcContext = TestUtils.getARCContext(isStreaming=false)
+    import spark.implicits._
+
+    // create single row dataset
+    val df = Seq((s"testKey,testValue")).toDF("value")
+    df.createOrReplaceTempView("inputView")
+
+    val conf = s"""
+    {
+      "plugins": {
+        "lifecycle": [
+          {
+            "type": "ai.tripl.arc.plugins.TestLifecyclePlugin",
+            "environments": ["test"],
+            "name": "level0",
+            "outputViewBefore": "level0before",
+            "outputViewAfter": "level0after",
+            "value": "level0"
+          }
+        ],
+      },      
+      "stages": [
+        {
+          "type": "PipelineExecute",
+          "name": "embed the active customer pipeline",
+          "environments": [
+            "production",
+            "test"
+          ],
+          "uri": "${spark.getClass.getResource("/conf/").toString}/pipeline_execute.conf",
+        }
+      ]
+    }
+    """
+
+    val pipelineEither = ArcPipeline.parseConfig(Left(conf), arcContext)
+
+    pipelineEither match {
+      case Left(err) => fail(err.toString)
+      case Right((pipeline, ctx)) => ARC.run(pipeline)(spark, logger, ctx)
+    }
+
+    val expectedBeforeLevel0 = Seq(("delimited extract", "before", "level0")).toDF("stage","when","message")
+    assert(TestUtils.datasetEquality(expectedBeforeLevel0, spark.table("level0before")))
+
+    val expectedAfterLevel0 = Seq(("delimited extract", "after", "level0", 1L)).toDF("stage","when","message","count")
+    assert(TestUtils.datasetEquality(expectedAfterLevel0, spark.table("level0after")))    
+
+    val expectedBeforeLevel1 = Seq(("delimited extract", "before", "level1")).toDF("stage","when","message")
+    assert(TestUtils.datasetEquality(expectedBeforeLevel1, spark.table("level1before")))
+
+    val expectedAfterLevel1 = Seq(("delimited extract", "after", "level1", 1L)).toDF("stage","when","message","count")
+    assert(TestUtils.datasetEquality(expectedAfterLevel1, spark.table("level1after")))        
+
+  }
+
+}

--- a/src/test/scala/ai/tripl/arc/plugins/LifecyclePluginSuite.scala
+++ b/src/test/scala/ai/tripl/arc/plugins/LifecyclePluginSuite.scala
@@ -38,6 +38,7 @@ class LifecyclePluginSuite extends FunSuite with BeforeAndAfter {
     implicit val arcContext = TestUtils.getARCContext(isStreaming=false)
     import spark.implicits._
 
+    // create single row dataset
     val df = Seq((s"testKey,testValue")).toDF("value")
     df.createOrReplaceTempView("inputView")
 


### PR DESCRIPTION
- this pr adds lifecycle plugins from any nest PipelineExecute stage meaning that nested stages behave just like regular jobs and opens up the opportunity to wrap other jobs with master jobs and not lose any functionality