### PR TITLE
Feature/s3 bucket permission

### DIFF
--- a/docs-src/content/partials/index.md
+++ b/docs-src/content/partials/index.md
@@ -13,7 +13,7 @@ The `Authentication` map defines the authentication parameters for connecting to
 
 | Attribute | Type | Required | Description |
 |-----------|------|----------|-------------|
-|method|String|true|A value of `AzureSharedKey`, `AzureSharedAccessSignature`, `AzureDataLakeStorageToken`, `AzureDataLakeStorageGen2AccountKey`, `AzureDataLakeStorageGen2OAuth`, `AmazonAccessKey`, `AmazonAnonymous`, `AmazonIAM`, `GoogleCloudStorageKeyFile` which defines which method should be used to authenticate with the remote service.|
+|method|String|true|A value of `AzureSharedKey`, `AzureSharedAccessSignature`, `AzureDataLakeStorageToken`, `AzureDataLakeStorageGen2AccountKey`, `AzureDataLakeStorageGen2OAuth`, `AmazonAccessKey`, `AmazonAnonymous`, `AmazonIAM`, `AmazonEnvironmentVariable`, `GoogleCloudStorageKeyFile` which defines which method should be used to authenticate with the remote service.|
 |accountName|String|false*|Required for `AzureSharedKey` and `AzureSharedAccessSignature`.|
 |signature|String|false*|Required for `AzureSharedKey`.|
 |container|String|false*|Required for `AzureSharedAccessSignature`.|

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,6 @@ object Dependencies {
   // hadoop
   val hadoopCommon =  "org.apache.hadoop" % "hadoop-common" % hadoopVersion
   val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion  
-  val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.199"
 
   // spark XML
   val sparkXML = "com.databricks" %% "spark-xml" % "0.9.0" 
@@ -36,7 +35,6 @@ object Dependencies {
     jetty,
     hadoopCommon,
     hadoopAWS,
-    awsS3,
     postgresJDBC,
     sqlServerJDBC,
     sparkCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
   // hadoop
   val hadoopCommon =  "org.apache.hadoop" % "hadoop-common" % hadoopVersion
   val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion  
+  val awsS3 = "com.amazonaws" % "aws-java-sdk-s3" % "1.11.199"
 
   // spark XML
   val sparkXML = "com.databricks" %% "spark-xml" % "0.9.0" 
@@ -35,6 +36,7 @@ object Dependencies {
     jetty,
     hadoopCommon,
     hadoopAWS,
+    awsS3,
     postgresJDBC,
     sqlServerJDBC,
     sparkCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,6 @@ object Dependencies {
   val scalaTest = "org.scalatest" %% "scalatest" % "3.0.7" % "test,it"
   val jetty = "org.mortbay.jetty" % "jetty" % "6.1.26" % "test,it"
   val postgresJDBC = "org.postgresql" % "postgresql" % "42.2.8" % "test,it" 
-  val hadoopCommon =  "org.apache.hadoop" % "hadoop-common" % hadoopVersion % "it"
-  val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion % "it"
   val sqlServerJDBC = "com.microsoft.sqlserver" % "mssql-jdbc" % "7.4.1.jre8" % "it" 
 
   // spark
@@ -22,6 +20,10 @@ object Dependencies {
   val sparkHive = "org.apache.spark" %% "spark-hive" % sparkVersion % "provided" 
   val sparkMl = "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided"
   val sparkAvro = "org.apache.spark" %% "spark-avro" % sparkVersion % "provided"
+
+  // hadoop
+  val hadoopCommon =  "org.apache.hadoop" % "hadoop-common" % hadoopVersion
+  val hadoopAWS = "org.apache.hadoop" % "hadoop-aws" % hadoopVersion  
 
   // spark XML
   val sparkXML = "com.databricks" %% "spark-xml" % "0.9.0" 

--- a/src/main/scala/ai/tripl/arc/api/API.scala
+++ b/src/main/scala/ai/tripl/arc/api/API.scala
@@ -324,9 +324,16 @@ object API {
       to provide access to a KMS key that would need to be done via a role and SSE-S3 should work if
       enable on the bucket as the default. Therefor unless a use case appears for adding encryption
       options to the access key method we will only support encryption options when using IAM for now.
+
+      for arc we are using this dependency resolution order if authentication is not provided:
+
      */
-    case class AmazonAccessKey(accessKeyID: String, secretAccessKey: String, endpoint: Option[String], ssl: Option[Boolean]) extends Authentication
-    case class AmazonIAM(encryptionType: Option[AmazonS3EncryptionType], keyArn: Option[String], customKey: Option[String]) extends Authentication
+    case class AmazonAccessKey(bucket: String, accessKeyID: String, secretAccessKey: String, endpoint: Option[String], ssl: Option[Boolean]) extends Authentication
+    case class AmazonAnonymous(bucket: String) extends Authentication
+    case class AmazonEnvironmentVariable(bucket: String, accessKeyID: String, secretAccessKey: String) extends Authentication
+    case class AmazonIAM(bucket: String, encryptionType: Option[AmazonS3EncryptionType], keyArn: Option[String], customKey: Option[String]) extends Authentication
+
+
     case class AzureSharedKey(accountName: String, signature: String) extends Authentication
     case class AzureSharedAccessSignature(accountName: String, container: String, token: String) extends Authentication
     case class AzureDataLakeStorageToken(clientID: String, refreshToken: String) extends Authentication

--- a/src/main/scala/ai/tripl/arc/api/API.scala
+++ b/src/main/scala/ai/tripl/arc/api/API.scala
@@ -328,10 +328,10 @@ object API {
       for arc we are using this dependency resolution order if authentication is not provided:
 
      */
-    case class AmazonAccessKey(bucket: String, accessKeyID: String, secretAccessKey: String, endpoint: Option[String], ssl: Option[Boolean]) extends Authentication
-    case class AmazonAnonymous(bucket: String) extends Authentication
-    case class AmazonEnvironmentVariable(bucket: String, accessKeyID: String, secretAccessKey: String) extends Authentication
-    case class AmazonIAM(bucket: String, encryptionType: Option[AmazonS3EncryptionType], keyArn: Option[String], customKey: Option[String]) extends Authentication
+    case class AmazonAccessKey(bucket: Option[String], accessKeyID: String, secretAccessKey: String, endpoint: Option[String], ssl: Option[Boolean]) extends Authentication
+    case class AmazonAnonymous(bucket: Option[String]) extends Authentication
+    case class AmazonEnvironmentVariable(bucket: Option[String]) extends Authentication
+    case class AmazonIAM(bucket: Option[String], encryptionType: Option[AmazonS3EncryptionType], keyArn: Option[String], customKey: Option[String]) extends Authentication
 
 
     case class AzureSharedKey(accountName: String, signature: String) extends Authentication

--- a/src/main/scala/ai/tripl/arc/config/ConfigUtils.scala
+++ b/src/main/scala/ai/tripl/arc/config/ConfigUtils.scala
@@ -391,6 +391,10 @@ object ConfigUtils {
 
     def err(lineNumber: Option[Int], msg: String): Either[Errors, Option[Authentication]] = Left(ConfigError(path, lineNumber, msg) :: Nil)
 
+    def getURIAuthority(uri: Option[String]): Option[String] = {
+      uri.map { new URI(_).getAuthority }
+    }
+
     try {
       if (c.hasPath(path)) {
         val authentication = readMap("authentication", c)
@@ -471,7 +475,7 @@ object ConfigUtils {
               Right(Some(Authentication.AzureDataLakeStorageGen2OAuth(clientID, secret, directoryID)))
             }
             case Some("AmazonAccessKey") => {
-              val s3aBucket = uri.map { new URI(_).getAuthority }
+              val s3aBucket = getURIAuthority(uri)
               val accessKeyID = authentication.get("accessKeyID") match {
                 case Some(v) => v
                 case None => throw new Exception(s"Authentication method 'AmazonAccessKey' requires 'accessKeyID' parameter.")
@@ -503,15 +507,15 @@ object ConfigUtils {
               Right(Some(Authentication.AmazonAccessKey(s3aBucket, accessKeyID, secretAccessKey, endpoint, sslEnabled)))
             }
             case Some("AmazonAnonymous") => {
-              val s3aBucket = uri.map { new URI(_).getAuthority }
+              val s3aBucket = getURIAuthority(uri)
               Right(Some(Authentication.AmazonAnonymous(s3aBucket)))
             }        
             case Some("AmazonEnvironmentVariable") => {
-              val s3aBucket = uri.map { new URI(_).getAuthority }
+              val s3aBucket = getURIAuthority(uri)
               Right(Some(Authentication.AmazonEnvironmentVariable(s3aBucket)))
             }                      
             case Some("AmazonIAM") => {
-              val s3aBucket = uri.map { new URI(_).getAuthority }
+              val s3aBucket = getURIAuthority(uri)
               val encType = authentication.get("encryptionAlgorithm").flatMap( AmazonS3EncryptionType.fromString(_) )
               val kmsId = authentication.get("kmsArn")
               val customKey = authentication.get("customKey")

--- a/src/main/scala/ai/tripl/arc/config/ConfigUtils.scala
+++ b/src/main/scala/ai/tripl/arc/config/ConfigUtils.scala
@@ -65,7 +65,7 @@ object ConfigUtils {
         throw new Exception("s3:// and s3n:// are no longer supported. Please use s3a:// instead.")
       case "s3" | "s3a" => {
 
-        val s3aURI = new AmazonS3URI(uri.replaceFirst("s3a://","s3://"))
+        val s3aBucket = new AmazonS3URI(uri.toString.replaceFirst("s3a://","s3://")).getBucket
         val s3aAccessKey: Option[String] = arcContext.commandLineArguments.get("etl.config.fs.s3a.access.key").orElse(envOrNone("ETL_CONF_S3A_ACCESS_KEY"))
         val s3aSecretKey: Option[String] = arcContext.commandLineArguments.get("etl.config.fs.s3a.secret.key").orElse(envOrNone("ETL_CONF_S3A_SECRET_KEY"))
         val s3aEndpoint: Option[String] = arcContext.commandLineArguments.get("etl.config.fs.s3a.endpoint").orElse(envOrNone("ETL_CONF_S3A_ENDPOINT"))
@@ -92,16 +92,16 @@ object ConfigUtils {
               }
               case None => None
             }
-            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonAccessKey(s3aURI.getBucket, accessKey, secretKey, s3aEndpoint, connectionSSLEnabled)))
+            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonAccessKey(Option(s3aBucket), accessKey, secretKey, s3aEndpoint, connectionSSLEnabled)))
           }
           case (None, _, _, _, Some(AmazonS3EncryptionType.SSE_S3), None, None) =>
-            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(s3aURI.getBucket, s3aEncType, s3aKmsId, None)))
+            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(Option(s3aBucket), s3aEncType, s3aKmsId, None)))
           case (None, _, _, _, Some(AmazonS3EncryptionType.SSE_KMS), None, None) =>
-            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(s3aURI.getBucket, s3aEncType, s3aKmsId, None)))
+            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(Option(s3aBucket), s3aEncType, s3aKmsId, None)))
           case (None, _, _, _, Some(AmazonS3EncryptionType.SSE_C), None, None) =>
-            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(s3aURI.getBucket, s3aEncType, None, s3aCustomKey)))   
+            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(Option(s3aBucket), s3aEncType, None, s3aCustomKey)))   
           case _ =>
-            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(s3aURI.getBucket, None, None, None)))
+            CloudUtils.setHadoopConfiguration(Some(Authentication.AmazonIAM(Option(s3aBucket), None, None, None)))
         }
 
         val etlConfString = CloudUtils.getTextBlob(uri)
@@ -389,7 +389,7 @@ object ConfigUtils {
     }
   }
 
-  def readAuthentication(path: String)(implicit c: Config): Either[Errors, Option[Authentication]] = {
+  def readAuthentication(path: String, uri: Option[String] = None)(implicit c: Config): Either[Errors, Option[Authentication]] = {
 
     def err(lineNumber: Option[Int], msg: String): Either[Errors, Option[Authentication]] = Left(ConfigError(path, lineNumber, msg) :: Nil)
 
@@ -473,7 +473,7 @@ object ConfigUtils {
               Right(Some(Authentication.AzureDataLakeStorageGen2OAuth(clientID, secret, directoryID)))
             }
             case Some("AmazonAccessKey") => {
-              val s3aURI = new AmazonS3URI(uri.replaceFirst("s3a://","s3://"))
+              val s3aBucket = uri.map { uri => new AmazonS3URI(uri.replaceFirst("s3a://","s3://")).getBucket }
               val accessKeyID = authentication.get("accessKeyID") match {
                 case Some(v) => v
                 case None => throw new Exception(s"Authentication method 'AmazonAccessKey' requires 'accessKeyID' parameter.")
@@ -502,22 +502,31 @@ object ConfigUtils {
                 }
                 case None => None
               }
-              Right(Some(Authentication.AmazonAccessKey(accessKeyID, secretAccessKey, endpoint, sslEnabled)))
+              Right(Some(Authentication.AmazonAccessKey(s3aBucket, accessKeyID, secretAccessKey, endpoint, sslEnabled)))
             }
+            case Some("AmazonAnonymous") => {
+              val s3aBucket = uri.map { uri => new AmazonS3URI(uri.replaceFirst("s3a://","s3://")).getBucket }
+              Right(Some(Authentication.AmazonAnonymous(s3aBucket)))
+            }        
+            case Some("AmazonEnvironmentVariable") => {
+              val s3aBucket = uri.map { uri => new AmazonS3URI(uri.replaceFirst("s3a://","s3://")).getBucket }
+              Right(Some(Authentication.AmazonEnvironmentVariable(s3aBucket)))
+            }                      
             case Some("AmazonIAM") => {
+              val s3aBucket = uri.map { uri => new AmazonS3URI(uri.replaceFirst("s3a://","s3://")).getBucket }
               val encType = authentication.get("encryptionAlgorithm").flatMap( AmazonS3EncryptionType.fromString(_) )
               val kmsId = authentication.get("kmsArn")
               val customKey = authentication.get("customKey")
 
               (encType, kmsId, customKey) match {
                 case (None, None, None) =>
-                  Right(Some(Authentication.AmazonIAM(None, None, None)))
+                  Right(Some(Authentication.AmazonIAM(s3aBucket, None, None, None)))
                 case (Some(AmazonS3EncryptionType.SSE_S3), None, None) =>
-                  Right(Some(Authentication.AmazonIAM(encType, kmsId, None)))
+                  Right(Some(Authentication.AmazonIAM(s3aBucket, encType, kmsId, None)))
                 case (Some(AmazonS3EncryptionType.SSE_KMS), Some(arn), None) =>
-                  Right(Some(Authentication.AmazonIAM(encType, kmsId, None)))
+                  Right(Some(Authentication.AmazonIAM(s3aBucket, encType, kmsId, None)))
                 case (Some(AmazonS3EncryptionType.SSE_C), None, Some(k)) =>
-                  Right(Some(Authentication.AmazonIAM(encType, None, customKey)))
+                  Right(Some(Authentication.AmazonIAM(s3aBucket, encType, None, customKey)))
                 case _ =>
                   throw new Exception(s"Invalid authentication options for AmazonIAM method. See docs for allowed settings.")
               }


### PR DESCRIPTION
this change allows AWS Authentication default providers to be overridden at a stage level.

This means that if running with an IAM role on an instance (using `InstanceProfileCredentialsProvider`)  it is possible to override a single stage with an AmazonAnonymous for example which would override `InstanceProfileCredentialsProvider` with `AnonymousAWSCredentialsProvider` for that specific bucket only.